### PR TITLE
M6Q.2: Instruction packet gate (novel_ask + answer_path)

### DIFF
--- a/src/safe-path.ts
+++ b/src/safe-path.ts
@@ -1,4 +1,4 @@
-import { sep } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 
 import { NovelCliError } from "./errors.js";
 
@@ -18,3 +18,15 @@ export function assertInsideProjectRoot(projectRootAbs: string, absolutePath: st
   }
 }
 
+export function resolveProjectRelativePath(projectRootAbs: string, relPath: string, label: string): string {
+  if (typeof relPath !== "string" || relPath.trim().length === 0) {
+    throw new NovelCliError(`Invalid ${label}: must be a non-empty string.`, 2);
+  }
+  if (isAbsolute(relPath)) {
+    throw new NovelCliError(`Invalid ${label}: must be a project-relative path.`, 2);
+  }
+  rejectPathTraversalInput(relPath, label);
+  const abs = join(projectRootAbs, relPath);
+  assertInsideProjectRoot(projectRootAbs, abs);
+  return abs;
+}


### PR DESCRIPTION
Closes #85

- Extend instruction packet type to optionally carry `novel_ask` + `answer_path`
- Add gate helpers to load/require a valid AnswerSpec for deterministic resume + blocking semantics
- Keep backward compatibility for packets without gates