### PR TITLE
feat: foreshadow visibility (dormancy + light-touch tasks) (#58)

### DIFF
--- a/agents/chapter-writer.md
+++ b/agents/chapter-writer.md
@@ -20,6 +20,7 @@
 - storyline_context（last_chapter_summary / chapters_since_last / line_arc_progress）
 - hard_rules_list（L1 禁止项列表）
 - foreshadowing_tasks（本章伏笔任务）
+- foreshadow_light_touch_tasks（可选；伏笔沉默超阈值时注入的“轻触提醒”任务：非剧透、不兑现）
 - ai_blacklist_top10（高频词提醒）
 - concurrent_state（其他线并发状态）
 - transition_hint（切线过渡提示）
@@ -54,7 +55,7 @@
 3. 阅读本章大纲，明确核心冲突和目标
 4. 检查前一章摘要，确保自然衔接
 5. 确认当前故事线和 POV 角色
-6. 检查伏笔任务，在正文中自然植入
+6. 检查伏笔任务与轻触提醒（如有），在正文中自然植入
 7. 开始创作——以 style_exemplars 的质感为锚点，writing_directives 的 DO 示例为句式参照
 8. 创作过程中持续检查角色言行是否符合 L2 契约
 9. **风格自检**：完成正文后，抽取 3 个段落与 `style_exemplars` 对比——如果节奏感、用词密度或句式结构明显偏离，定向修改偏离段落

--- a/skills/continue/references/context-contracts.md
+++ b/skills/continue/references/context-contracts.md
@@ -33,6 +33,9 @@ chapter_writer_manifest = {
   transition_hint: obj | null,          # 切线过渡
   hard_rules_list: [str],              # L1 禁止项列表（已格式化）
   foreshadowing_tasks: [obj],          # 本章伏笔任务子集
+  foreshadow_light_touch_tasks: [      # 可选：伏笔沉默超阈值时的“轻触提醒”（非剧透、不兑现）
+    {id: str, scope: str, status: str, chapters_since_last_update: int, instruction: str}
+  ] | null,
   ai_blacklist_top10: [str],           # 有效黑名单前 10 词
   style_drift_directives: [str] | null, # 漂移纠偏指令（active 时注入）
 

--- a/src/foreshadow-visibility.ts
+++ b/src/foreshadow-visibility.ts
@@ -1,0 +1,191 @@
+import { join } from "node:path";
+
+import { ensureDir, pathExists, readJsonFile, writeJsonFile } from "./fs-utils.js";
+import type { PlatformId } from "./platform-profile.js";
+import { pad2, pad3 } from "./steps.js";
+import { isPlainObject } from "./type-guards.js";
+
+type ForeshadowScope = "short" | "medium" | "long";
+type ForeshadowStatus = "planted" | "advanced" | "resolved";
+
+type DormancyThresholds = Record<ForeshadowScope, number>;
+
+export type ForeshadowDormancyItem = {
+  id: string;
+  description: string | null;
+  scope: ForeshadowScope;
+  status: ForeshadowStatus;
+  last_updated_chapter: number;
+  chapters_since_last_update: number;
+  dormancy_threshold: number;
+  planning_task: string;
+  writing_task: string;
+};
+
+export type ForeshadowVisibilityReport = {
+  schema_version: 1;
+  generated_at: string;
+  as_of: { chapter: number; volume: number };
+  platform: PlatformId | null;
+  genre_drive_type: string | null;
+  thresholds: DormancyThresholds;
+  dormant_items: ForeshadowDormancyItem[];
+  counts: { dormant_total: number; dormant_by_scope: Record<ForeshadowScope, number> };
+};
+
+type ForeshadowRawItem = Record<string, unknown> & {
+  id: string;
+  description?: unknown;
+  scope?: unknown;
+  status?: unknown;
+  planted_chapter?: unknown;
+  last_updated_chapter?: unknown;
+};
+
+function safeInt(v: unknown): number | null {
+  return typeof v === "number" && Number.isInteger(v) ? v : null;
+}
+
+function safeString(v: unknown): string | null {
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+}
+
+function normalizeScope(raw: unknown): ForeshadowScope {
+  if (raw === "short" || raw === "medium" || raw === "long") return raw;
+  return "medium";
+}
+
+function normalizeStatus(raw: unknown): ForeshadowStatus {
+  if (raw === "planted" || raw === "advanced" || raw === "resolved") return raw;
+  return "planted";
+}
+
+export function deriveForeshadowDormancyThresholds(genreDriveType: string | null): DormancyThresholds {
+  // Base thresholds in chapters; adjusted by genre_drive_type.
+  // Intent: keep long-scope items from going silent too long, without forcing spoilers.
+  const base: DormancyThresholds = { short: 6, medium: 12, long: 24 };
+  const dt = genreDriveType ?? "";
+  const adjust = dt === "suspense" ? -3 : dt === "plot" ? -2 : dt === "character" ? -1 : dt === "slice_of_life" ? 2 : 0;
+  const clamp = (n: number): number => Math.max(1, n);
+  return {
+    short: clamp(base.short + adjust),
+    medium: clamp(base.medium + adjust),
+    long: clamp(base.long + adjust)
+  };
+}
+
+function normalizeForeshadowList(raw: unknown): ForeshadowRawItem[] {
+  const list = Array.isArray(raw) ? raw : isPlainObject(raw) && Array.isArray((raw as Record<string, unknown>).foreshadowing) ? (raw as any).foreshadowing : [];
+  const out: ForeshadowRawItem[] = [];
+  for (const it of list) {
+    if (!isPlainObject(it)) continue;
+    const id = safeString((it as Record<string, unknown>).id);
+    if (!id) continue;
+    out.push({ ...(it as Record<string, unknown>), id } as ForeshadowRawItem);
+  }
+  return out;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function makeLightTouchTasks(args: {
+  id: string;
+  label: string;
+  scope: ForeshadowScope;
+  status: ForeshadowStatus;
+  chaptersSince: number;
+}): { planning_task: string; writing_task: string } {
+  const scopeHint = args.scope === "short" ? "短期" : args.scope === "medium" ? "中期" : "长期";
+  const statusHint = args.status === "resolved" ? "已回收" : args.status === "advanced" ? "已推进" : "已埋设";
+  const common = `伏笔「${args.label}」已沉默 ${args.chaptersSince} 章（${scopeHint}/${statusHint}）`;
+  return {
+    planning_task: `${common}。建议在接下来几章安排一次“轻触”回响（象征/道具/一句话提及），保持读者记忆，不要提前兑现。`,
+    writing_task: `${common}。本章请用 1 句/1 个意象/1 个小动作做“轻触”回响（不解释、不揭底、不兑现）。`
+  };
+}
+
+export function computeForeshadowVisibilityReport(args: {
+  items: ForeshadowRawItem[];
+  asOfChapter: number;
+  volume: number;
+  platform: PlatformId | null;
+  genreDriveType: string | null;
+}): ForeshadowVisibilityReport {
+  if (!Number.isInteger(args.asOfChapter) || args.asOfChapter < 0) throw new Error(`Invalid asOfChapter: ${String(args.asOfChapter)}`);
+  if (!Number.isInteger(args.volume) || args.volume < 0) throw new Error(`Invalid volume: ${String(args.volume)}`);
+
+  const thresholds = deriveForeshadowDormancyThresholds(args.genreDriveType);
+
+  const dormant: ForeshadowDormancyItem[] = [];
+  for (const it of args.items) {
+    const status = normalizeStatus(it.status);
+    if (status === "resolved") continue;
+    const scope = normalizeScope(it.scope);
+    const lastUpdated = safeInt(it.last_updated_chapter) ?? safeInt(it.planted_chapter) ?? 0;
+    const chaptersSince = Math.max(0, args.asOfChapter - lastUpdated);
+    const threshold = thresholds[scope];
+    if (chaptersSince < threshold) continue;
+
+    const description = safeString(it.description);
+    const label = description ?? it.id;
+    const tasks = makeLightTouchTasks({ id: it.id, label, scope, status, chaptersSince });
+    dormant.push({
+      id: it.id,
+      description,
+      scope,
+      status,
+      last_updated_chapter: lastUpdated,
+      chapters_since_last_update: chaptersSince,
+      dormancy_threshold: threshold,
+      ...tasks
+    });
+  }
+
+  dormant.sort((a, b) => b.chapters_since_last_update - a.chapters_since_last_update || compareStrings(a.scope, b.scope) || compareStrings(a.id, b.id));
+
+  const dormantByScope: Record<ForeshadowScope, number> = { short: 0, medium: 0, long: 0 };
+  for (const it of dormant) dormantByScope[it.scope] += 1;
+
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    as_of: { chapter: args.asOfChapter, volume: args.volume },
+    platform: args.platform,
+    genre_drive_type: args.genreDriveType,
+    thresholds,
+    dormant_items: dormant,
+    counts: { dormant_total: dormant.length, dormant_by_scope: dormantByScope }
+  };
+}
+
+export async function writeForeshadowVisibilityLogs(args: {
+  rootDir: string;
+  report: ForeshadowVisibilityReport;
+  historyRange?: { start: number; end: number } | null;
+}): Promise<{ latestRel: string; historyRel?: string }> {
+  const dirRel = "logs/foreshadowing";
+  const dirAbs = join(args.rootDir, dirRel);
+  await ensureDir(dirAbs);
+
+  const latestRel = `${dirRel}/latest.json`;
+  await writeJsonFile(join(args.rootDir, latestRel), args.report);
+
+  if (!args.historyRange) return { latestRel };
+  const start = args.historyRange.start;
+  const end = args.historyRange.end;
+  const historyRel = `${dirRel}/foreshadowing-check-vol-${pad2(args.report.as_of.volume)}-ch${pad3(start)}-ch${pad3(end)}.json`;
+  await writeJsonFile(join(args.rootDir, historyRel), args.report);
+  return { latestRel, historyRel };
+}
+
+export async function loadForeshadowGlobalItems(rootDir: string): Promise<ForeshadowRawItem[]> {
+  const rel = "foreshadowing/global.json";
+  const abs = join(rootDir, rel);
+  if (!(await pathExists(abs))) return [];
+  const raw = await readJsonFile(abs);
+  return normalizeForeshadowList(raw);
+}

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -4,6 +4,7 @@ import type { Checkpoint } from "./checkpoint.js";
 import { NovelCliError } from "./errors.js";
 import { ensureDir, pathExists, readTextFile, writeJsonFile } from "./fs-utils.js";
 import { loadContinuityLatestSummary } from "./consistency-auditor.js";
+import { computeForeshadowVisibilityReport, loadForeshadowGlobalItems } from "./foreshadow-visibility.js";
 import { computeEffectiveScoringWeights, loadGenreWeightProfiles } from "./scoring-weights.js";
 import { parseNovelAskQuestionSpec, type NovelAskQuestionSpec } from "./novel-ask.js";
 import { loadPlatformProfile } from "./platform-profile.js";
@@ -97,6 +98,31 @@ export async function buildInstructionPacket(args: BuildArgs): Promise<Record<st
 
   if (args.step.stage === "draft") {
     agent = { kind: "subagent", name: "chapter-writer" };
+    // Optional: inject non-spoiler light-touch reminders for dormant foreshadowing items (best-effort).
+    try {
+      const loadedPlatform = await loadPlatformProfile(args.rootDir).catch(() => null);
+      const platform = loadedPlatform?.profile.platform ?? null;
+      const genreDriveType = typeof loadedPlatform?.profile.scoring?.genre_drive_type === "string" ? loadedPlatform.profile.scoring.genre_drive_type : null;
+
+      const items = await loadForeshadowGlobalItems(args.rootDir);
+      const report = computeForeshadowVisibilityReport({
+        items,
+        asOfChapter: args.step.chapter,
+        volume,
+        platform,
+        genreDriveType
+      });
+      const tasks = report.dormant_items.slice(0, 5).map((it) => ({
+        id: it.id,
+        scope: it.scope,
+        status: it.status,
+        chapters_since_last_update: it.chapters_since_last_update,
+        instruction: it.writing_task
+      }));
+      if (tasks.length > 0) inline.foreshadow_light_touch_tasks = tasks;
+    } catch {
+      // ignore
+    }
     expected_outputs.push({ path: rel.staging.chapterMd, required: true });
     next_actions.push({ kind: "command", command: `novel validate ${stepId}` });
     next_actions.push({ kind: "command", command: `novel advance ${stepId}` });


### PR DESCRIPTION
Implements #58 on top of the CLI refactor branch (PR #109).

- Compute foreshadow dormancy (`chapters_since_last_update`) from `foreshadowing/global.json`
- Write `logs/foreshadowing/latest.json` after each `novel commit` (and a history snapshot every 10 chapters / volume-end)
- Inject non-spoiler “light-touch” reminder tasks into `novel instructions chapter:NNN:draft` (`manifest.inline.foreshadow_light_touch_tasks`, capped at 5)

Spec: `openspec/changes/m6-platform-optimization/specs/foreshadow-visibility/spec.md`
