### PR TITLE
docs: update README + user manual for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,151 +1,90 @@
-# novel-writer-cli — 中文网文 AI 协作创作 CLI
+# novel-writer-cli
 
-确定性编排 CLI + 9 个 AI Agent 协作完成网文创作全流程：世界观构建 → 卷级规划 → 章节续写 → 风格润色 → 质量验收 → 周期性一致性审计。内置去 AI 化四层策略和 Spec-Driven 规范体系，产出接近人类写手的长篇中文网络小说。
+执行器无关（executor-agnostic）的**确定性小说编排 CLI**：`novel` 负责计算下一步、生成 instruction packet、校验/推进 checkpoint、提交 staging 事务，并产出可审计的日志与报告。
 
-> **注**：本仓库为 CLI 版本，负责确定性编排与多 Agent 调度。Claude Code Plugin 版本见 [novel-writer-plugin](https://github.com/DankerMu/novel-writer-plugin)。
+`novel` **不调用任何 LLM API**。写作/润色/评审等 LLM 执行由 Claude Code、Codex 等外部执行器（executor）根据 instruction packet 来完成。
 
-## 快速开始
+- 用户手册索引：[`docs/user/README.md`](docs/user/README.md)
+- CLI 手册（最重要）：[`docs/user/novel-cli.md`](docs/user/novel-cli.md)
 
-### 前置条件
+> Claude Code Plugin 版本见 [novel-writer-plugin](https://github.com/DankerMu/novel-writer-plugin)。
+
+## 快速开始（开发态）
+
+前置条件：
 
 - Node.js 18+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) 已安装并登录
-- Python 3.10+（评估脚本需要）
 
-### 安装
+```bash
+npm install
+npm run build
+node dist/cli.js --help
+```
 
+> 发布到 npm 后，目标体验是 `npx novel ...` / `novel ...`。
 
+## 主要特性
 
-### 基本用法
+- **确定性流水线**：基于 `.checkpoint.json` + `staging/**` 计算下一步（可中断/可恢复）
+- **instruction packet 合约**：将“编排 → 执行器（LLM）”的边界固化为 JSON（可审计/可回放）
+- **写入事务**：`commit` 将 staging 产物提交到正式目录，并维护 `state/`、`foreshadowing/` 等工件
+- **Guardrails（可选）**：留存/可读性/命名等确定性检查，可触发 `...:title-fix` / `...:review` 等步骤
+- **叙事健康（可选）**：承诺台账、参与度密度、角色语气漂移等窗口化信号（默认 advisory-only）
 
+## 最小工作流：跑通一章
 
+在**小说项目根目录**（含 `.checkpoint.json`）运行：
 
-`novel` CLI **不调用任何 LLM API**，只负责确定性编排：读取 checkpoint、生成 instruction packet、校验产物、推进状态。LLM 执行由 Claude Code 或 Codex 等外部执行器完成。
+```bash
+# 1) 计算下一步
+novel next
 
-详见 [CLI 完整文档](docs/user/novel-cli.md)。
+# 2) 生成 instruction packet（给执行器用）
+novel instructions "chapter:003:draft" --json --write-manifest
 
-### 三个入口命令（Claude Code 集成）
+# 3) 执行器运行 packet.agent 指定的 subagent，写入 staging/**（此 repo 不负责跑 LLM）
 
-在 Claude Code 中可直接使用 Skill 命令：
+# 4) 校验与推进
+novel validate "chapter:003:draft"
+novel advance "chapter:003:draft"
 
-| 命令 | 用途 |
-|------|------|
-| `/novel:start` | 从创作纲领（brief）冷启动一个新项目 |
-| `/novel:continue` | 续写下一章 / 推进到下一卷 |
-| `/novel:status` | 查看当前项目进度、状态与统计 |
+# 5) 当 next 返回 ...:commit 时提交事务
+novel commit --chapter 3
+```
 
-**30 秒体验**：执行 `/novel:start`，按提示填写题材、主角和核心冲突，系统自动创建项目结构并试写 3 章。详见 [快速起步指南](docs/user/quick-start.md)。
+完整说明见：`docs/user/novel-cli.md`。
 
-### 推荐配套
+## 两层入口（CLI vs Skill）
 
-以下技能非必须，但能显著提升创作质量：
+本仓库文档里会出现两类命令：
 
-| 技能 | 用途 | 安装 |
-|------|------|------|
-| `doc-workflow` | 深度背景研究（历史/科幻/军事题材推荐） | 见 [CCskill 仓库](https://github.com/DankerMu/CCskill) |
-| `brainstorming` | 结构化脑暴（世界观/角色/情节设计） | 同上 |
-| `deep-research` | 多源信息综合研究 | 同上 |
+- **CLI 命令**：`novel ...`（确定性编排）
+- **Skill 入口**：`/novel:start`、`/novel:continue`、`/novel:status`（在 Claude Code 中使用；底层会调用 CLI 并运行 subagent）
 
-## 架构概览
+如果你只关心 CLI，请直接看 `docs/user/novel-cli.md`。
 
-### CLI 编排层
+## 主要命令
 
-`novel` CLI 是确定性编排核心，不依赖 LLM：
+运行 `novel --help` 可查看完整命令列表。核心命令包括：
 
+- `status` / `next` / `instructions` / `validate` / `advance` / `commit`
+- `lock status/clear`：写入锁管理（`.novel.lock/`）
+- `promises` / `engagement` / `voice`：叙事健康台账与指标（可选）
 
+## 仓库内容概览
 
-- **next**：从 `.checkpoint.json` + `staging/` 计算下一步
-- **instructions**：生成 instruction packet（JSON），作为编排→执行器的稳定边界
-- **validate**：校验 staging 产物合规性
-- **advance**：推进 checkpoint 状态
-- **commit**：将 staging 事务提交到正式目录，更新 `state/` 与 `foreshadowing/`
+- `src/`：CLI 实现（TypeScript）
+- `agents/`：subagent 提示词（由执行器运行）
+- `skills/`：Claude Code Skill 参考与编排素材
+- `schemas/`：项目 JSON/JSONL 文件的 SSOT schema
+- `docs/user/`：用户手册
 
-### 9 Agent 协作体系
+## 开发
 
-| Agent | 模型 | 职责 |
-|-------|------|------|
-| **WorldBuilder** | Opus | 世界观构建 + L1 硬规则（物理/魔法/社会） |
-| **CharacterWeaver** | Opus | 角色网络 + L2 契约（能力边界/行为模式） |
-| **PlotArchitect** | Opus | 卷级大纲 + L3 章节契约 + 故事线调度 |
-| **ChapterWriter** | Sonnet | 章节续写 + 多线叙事 + 防串线 |
-| **Summarizer** | Sonnet | 摘要 + 状态增量 + 串线检测 |
-| **StyleAnalyzer** | Sonnet | 用户样本 → 风格指纹 (`style-profile.json`) |
-| **StyleRefiner** | Opus | 去 AI 化润色（黑名单替换 + 风格匹配） |
-| **QualityJudge** | Sonnet | 双轨验收：合规检查 + 8 维度评分 |
-| **ConsistencyAuditor** | Sonnet | 滑动窗口一致性审计（stride=5, window=10）+ 卷末全卷审计 |
-
-### Spec-Driven 四层规范
-
-写小说如同写代码——规范先行，验收对齐规范：
-
-| 层级 | 内容 | 约束强度 |
-|------|------|----------|
-| **L1** 世界规则 | `rules.json` — 不可违反的硬约束 | 铁律 |
-| **L2** 角色契约 | `contracts/` — 能力/行为边界 | 可变更需走协议 |
-| **L3** 章节契约 | `chapter-contracts/` — 前/后置条件 | 可协商须留痕 |
-| **LS** 故事线 | `storylines.json` — 多线叙事约束 | 跨线泄漏为硬违规 |
-
-### 卷制滚动工作流
-
-网文采用「边写边想」模式，以卷（30-50 章）为单位滚动推进：
-
-
-
-每章经过完整流水线：
-
-
-
-### 质量门控
-
-8 维度加权评分（1-5 分）：
-
-
-
-五档门控决策：≥4.0 通过 → ≥3.5 二次润色 → ≥3.0 自动修订 → ≥2.0 人工审核 → <2.0 强制重写。关键章节启用 Sonnet + Opus 双裁判。
-
-### 去 AI 化策略
-
-四层流水线确保输出像人写的：
-
-1. **风格锚定**：从用户样本提取风格指纹
-2. **约束注入**：AI 黑名单 + 语癖 + 句式多样化
-3. **后处理**：StyleRefiner 替换 AI 用语 + 匹配风格
-4. **检测度量**：黑名单命中 < 3 次/千字，相邻 5 句重复句式 < 2
-
-## 项目结构
-
-
-
-## 评估与回归
-
-项目内置完整的评估基础设施，用于校准 QualityJudge 并跟踪质量回归：
-
-
-
-## CI
-
-PR 合入 `main` 自动触发：
-
-- **Markdown lint** — `npx markdownlint-cli2 "docs/**/*.md"`
-- **链接检查** — `lychee` 死链扫描
-- **Manifest 校验** — `manifest.json` 结构完整性
-
-## 开发进度
-
-| 里程碑 | 描述 | 状态 |
-|--------|------|------|
-| **M1** | 续写引擎基础（9 Agent + 3 Entry Skill + 模板） | 已完成 |
-| **M2** | Context 组装与状态机（Orchestrator + Spec 注入 + Hooks） | 已完成 |
-| **M3** | 质量门控与分析（5 档门控 + 双裁判 + NER + 伏笔 + 回归） | 已完成 |
-| **M4** | 端到端打磨（Quick Start + 跨卷 + E2E 基准） | 进行中 |
-| **M5** | CLI 编排核心（确定性编排 + instruction packet + Codex 集成） | 进行中 |
-
-详见 [progress.md](progress.md)。
+```bash
+npm test
+```
 
 ## 许可
 
 本项目尚未选定开源许可证。如需使用请先联系作者。
-
-## 作者
-
-**DankerMu** — [mumzy@mail.ustc.edu.cn](mailto:mumzy@mail.ustc.edu.cn)

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,17 @@
+# 用户手册
+
+本目录是 **novel-writer-cli** 的用户文档集合。这里的文档同时覆盖两层使用方式：
+
+- **CLI 层**：`novel ...`（确定性编排，不调用任何 LLM）
+- **执行器/Skill 层**：在 Claude Code / Codex 中使用 `/novel:*` 等入口命令（底层会调用 CLI，并运行各类 subagent）
+
+## 入口索引
+
+- 快速上手（Skill 入口）：[快速起步指南](quick-start.md)
+- CLI 手册（最重要）：[`novel` CLI](novel-cli.md)
+- 常用操作（Skill 入口）：[常用操作](ops.md)
+- 规范体系（文件/契约/平台画像）：[规范体系](spec-system.md)
+- Guardrails（留存/可读性/命名）：[Guardrails](guardrails.md)
+- 交互式门控（NOVEL_ASK）：[交互式门控](interactive-gates.md)
+- 故事线（storylines）：[故事线](storylines.md)
+

--- a/docs/user/guardrails.md
+++ b/docs/user/guardrails.md
@@ -2,7 +2,7 @@
 
 本项目的 Guardrails 是一组**确定性**检查：由 `platform-profile.json` 驱动，在 `novel next` 的关键节点生成可审计的 JSON 报告。当出现配置为 blocking 的问题时，`novel next` 会返回人工介入步骤（如 `...:review` / `...:title-fix`），阻止流水线推进到下一阶段。
 
-> **注意**：Pipeline 集成（tasks 6.1-6.3）尚在开发中，当前部分 blocking 行为可能尚未完全生效。以下描述的是设计目标行为。
+> **注意**：Guardrails 的判定发生在 CLI 层（`novel next`/`novel commit`）。当返回 `...:title-fix` / `...:review` 等步骤时，需要执行器按 instruction packet 约定运行对应 subagent，并在 `novel validate`/`novel advance` 后继续流水线。
 
 ## 配置入口：`platform-profile.json`
 

--- a/docs/user/novel-cli.md
+++ b/docs/user/novel-cli.md
@@ -7,6 +7,26 @@
 - 校验 `staging/**` 产物（validate）并推进 checkpoint（advance）
 - 将 `staging/**` 事务提交到正式目录（commit），并更新 `state/` 与 `foreshadowing/`
 
+## 全局选项
+
+- `--project <dir>`：指定小说项目根目录（默认从当前目录向上查找 `.checkpoint.json`）
+- `--json`：输出单个 JSON 对象（便于执行器/脚本消费）；不加时为人类可读输出
+
+## 命令速览
+
+| 命令 | 用途 |
+|------|------|
+| `novel status` | 查看 checkpoint / lock / next（只读） |
+| `novel next` | 计算确定性的下一步 step id |
+| `novel instructions <step>` | 输出 instruction packet（JSON） |
+| `novel validate <step>` | 校验 step 产物是否齐全/合规 |
+| `novel advance <step>` | 校验通过后推进 checkpoint |
+| `novel commit --chapter N` | 提交 staging 事务到正式目录（写入） |
+| `novel lock status/clear` | 查看/清理写入锁（解决中断导致的 stale lock） |
+| `novel promises init/report` | 承诺台账：初始化与窗口报告 |
+| `novel engagement report` | 参与度密度：窗口报告 |
+| `novel voice init/check` | 角色语气画像 + 漂移检测 |
+
 ## 本仓库开发态使用
 
 ```bash
@@ -47,6 +67,12 @@ novel instructions "chapter:003:draft" --json
 
 ```bash
 novel instructions "chapter:003:draft" --json --write-manifest
+```
+
+可选：为执行器提供少量内嵌内容（当前仅支持 `brief` 模式，注入 `brief.md` 的前 2000 字预览）。使用该选项后 `packet.manifest.mode` 会变为 `paths+embed`，并携带 `packet.manifest.embed.brief_preview`：
+
+```bash
+novel instructions "chapter:003:draft" --json --write-manifest --embed brief
 ```
 
 ### 3) 用执行器跑这一步（Claude Code / Codex）
@@ -101,6 +127,29 @@ commit 会执行（见 PRD §10.4）：
 - 合并 `staging/state/chapter-XXX-delta.json` → `state/current-state.json`（并 append `state/changelog.jsonl`）
 - 从 delta 的 `foreshadow` ops 更新 `foreshadowing/global.json`
 - 更新 `.checkpoint.json`：`last_completed_chapter`、`pipeline_stage="committed"`、`inflight_chapter=null`
+
+## `status`：快速查看项目状态（只读）
+
+```bash
+novel status
+# 或：novel status --json
+```
+
+输出包含：checkpoint 摘要、lock 状态、以及当前 `novel next` 会返回的下一步。
+
+## `lock`：写入锁（解决并发与中断残留）
+
+`novel` 在需要写入项目文件时会使用项目根目录下的 `.novel.lock/` 目录作为写入锁（防止多个会话同时写导致状态损坏）。
+
+```bash
+# 查看锁状态
+novel lock status
+
+# 清理 stale lock（默认 >30min 视为 stale；活跃锁会拒绝清理）
+novel lock clear
+```
+
+> 常见场景：执行器在写入阶段中断（断电/kill/异常退出），留下 stale lock；此时可先 `novel lock status` 确认，再执行 `novel lock clear`。
 
 ## 角色语气漂移（M7H.3，可选）
 

--- a/docs/user/ops.md
+++ b/docs/user/ops.md
@@ -2,6 +2,8 @@
 
 项目创建后的日常操作指南。
 
+> 本文描述的是 Claude Code Skill 入口（`/novel:*`）。这些入口会在底层调用 `novel` CLI，并通过执行器运行各 subagent。纯 CLI 编排参考见 [`novel` CLI](novel-cli.md)。
+
 ## 续写下一章
 
 ```

--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -2,6 +2,8 @@
 
 30 分钟内创建项目并试写 3 章。
 
+> 本指南以 Claude Code 的 Skill 入口（`/novel:start` 等）为主；底层会调用 `novel` CLI 并运行各 subagent。若你只想手动跑 CLI 编排，见 [`novel` CLI](novel-cli.md)。
+
 ## 准备
 
 - 安装 Claude Code CLI 并配置 `novel` CLI


### PR DESCRIPTION
## What
- Refresh root `README.md` to match the current executor-agnostic `novel` CLI (deterministic orchestration; no LLM calls).
- Add a user-manual index at `docs/user/README.md`.
- Update `docs/user/novel-cli.md` with current command surface (global options, command overview, `status`, `lock`, `--embed`).
- Clarify guardrails semantics: decisions happen in the CLI (`novel next`/`novel commit`); executors run the returned step packets.
- Add short notes to Skill-first docs (`quick-start.md`, `ops.md`) pointing to the pure CLI manual.

## Why
The CLI refactor has landed; docs needed to match the new split between:
- CLI orchestration (`novel ...`)
- executor / Claude Code Skills (`/novel:*`)

## Test
- `npm test`
