### PR TITLE
feat: expand QualityJudge indicator_breakdown 7→13

### DIFF
--- a/agents/quality-judge.md
+++ b/agents/quality-judge.md
@@ -160,7 +160,7 @@
 | immersion（沉浸感） | 0.15 | 画面感、氛围营造、详略得当 |
 | foreshadowing（伏笔处理） | 0.10 | 埋设自然度、推进合理性、回收满足感 |
 | pacing（节奏） | 0.08 | 冲突强度、爽点落地、铺垫有效性 |
-| style_naturalness（风格自然度） | 0.15 | 优先按 7 指标三区判定（Layer 4）；缺失时回退 Legacy 4 指标 |
+| style_naturalness（风格自然度） | 0.15 | 优先按 13 指标三区判定（Layer 4）；缺失时回退 7 指标或 Legacy 4 指标 |
 | emotional_impact（情感冲击） | 0.08 | 情感起伏、读者代入感 |
 | storyline_coherence（故事线连贯） | 0.08 | 切线流畅度、跟线难度、并发线暗示自然度 |
 

--- a/agents/quality-judge.md
+++ b/agents/quality-judge.md
@@ -209,7 +209,7 @@
 
 ### `style_naturalness` 评审口径
 
-默认使用 `indicator_mode: "7-indicator"`，按 `style-guide` Layer 4 的 7 指标三区判定：
+默认使用 `indicator_mode: "13-indicator"`，按 `style-guide` Layer 4 的 13 指标三区判定：
 
 1. `blacklist_hit_rate`
 2. `sentence_repetition_rate`
@@ -218,24 +218,38 @@
 5. `vocabulary_diversity_score`（若只有 `vocabulary_richness` 枚举代理，则按 `high / medium / low` 映射）
 6. `narration_connector_count`
 7. `humanize_technique_variety`
+8. `em_dash_count`
+9. `sentence_pattern_score`
+10. `simile_density`
+11. `dialogue_distinguishability`
+12. `ellipsis_density`
+13. `exclamation_density`
 
 执行要求：
 - 逐项给出 `green | yellow | red` 归类，并在 `style_naturalness.reason` 中解释主要拉分项
-- 同时在 `anti_ai.indicator_breakdown` 中结构化输出 7 个指标的 `value` / `zone` / `note`，不要只把它们埋在自由文本里
+- 同时在 `anti_ai.indicator_breakdown` 中结构化输出 13 个指标的 `value` / `zone` / `note`，不要只把它们埋在自由文本里
 - `anti_ai.indicator_breakdown` 用于逐指标审计和回看；`anti_ai.statistical_profile` 保留 3 个稳定字段，供 legacy / 轻量消费者读取。两者数值重叠是设计使然，不是冲突
 - `narration_connector_count` 的判定：0 = green；1 个孤立命中 = yellow（仍建议修）；≥2 个或连续多段靠连接词推进 = red
 - `humanize_technique_variety` 只做事后观察，不是配额：若整章 0 种技法且其他指标也健康，可记 yellow；若 0 种且伴随其他 red，则记 red
-- **破折号零容忍**：`punctuation_overuse.em_dash_count > 0` 时，在 `em_dash_zone` 输出 `"red"`；破折号是最明显的 AI 写作标志，零容忍无例外
-- **句式模式扣分**：对照 `paths.ai_sentence_patterns` 检测 8 种结构级 AI 句式模式，结果写入 `anti_ai.sentence_pattern_violations[]`（每条含 pattern_id / pattern_name / severity / count / evidence / detail）。扣分规则：0 处命中不扣分；1-2 处 medium 命中扣 0.5 分；≥1 处 high 命中至少降 1 分。与其他指标独立叠加
-- 只有在当前上下文无法可靠得到 7 指标时，才回退 `indicator_mode: "4-indicator-compat"`（旧 4 指标表）；典型条件包括：`chapter_draft` 过短/破损导致句长或段长无法稳定估算，或 `style_profile` 缺失且你只能可靠拿到旧 4 指标
+- **`em_dash_count`**：破折号（——）计数。0 = green；>0 = red（零容忍，无 yellow 区间）。同时保留 `punctuation_overuse.em_dash_count/em_dash_per_kchars/em_dash_zone` 原有输出
+- **`sentence_pattern_score`**：聚合 `sentence_pattern_violations[]` 的结果。0 处 high + ≤2 处 medium = green；>2 处 medium + 0 处 high = yellow；≥1 处 high = red。分项证据仍保留在 `sentence_pattern_violations[]` 中
+- **`simile_density`**：`像+具体意象`（如"像一把刀""像一根绷紧的弦"）的千字频率。排除非比喻义（"好像有人来了""像是累了"）。≤1/千字 = green；>1 且 ≤2/千字 = yellow；>2/千字 = red
+- **`dialogue_distinguishability`**：去掉对话标签后，仅凭语气、用词、句式能否分辨说话人。high = green（可辨识）；medium = yellow（勉强可辨识）；low = red（无法辨识）。由 LLM 基于正文估算，标注为"估计值"
+- **`ellipsis_density`**：省略号（……）千字频率。0-2/千字 = green；>2 且 ≤3/千字 = yellow；>3/千字 = red
+- **`exclamation_density`**：感叹号（！）千字频率。0-3/千字 = green；>3 且 ≤5/千字 = yellow；>5/千字 = red
+- **句式模式扣分**：对照 `paths.ai_sentence_patterns` 检测 8 种结构级 AI 句式模式，结果写入 `anti_ai.sentence_pattern_violations[]`（每条含 pattern_id / pattern_name / severity / count / evidence / detail）。扣分规则：0 处命中不扣分；1-2 处 medium 命中扣 0.5 分；≥1 处 high 命中至少降 1 分。与三区判定独立叠加
+- **回退层级**：
+  - `"13-indicator"`（默认）：正文 ≥500 字、`ai_sentence_patterns` 存在、对话内容足以评估
+  - `"7-indicator"`（中间回退）：正文过短（<500 字）导致比喻/对话样本不足，或 `ai_sentence_patterns` 未提供时，仅输出前 7 项
+  - `"4-indicator-compat"`（legacy）：正文破损或 style_profile 缺失且只能可靠拿到旧 4 指标时
 
 # Constraints
 
 1. **独立评分**：每个维度独立评分，附具体理由和引用原文
 2. **不给面子分**：明确指出问题而非回避
-3. **可量化**：风格自然度优先基于 7 指标（黑名单命中率、句式重复率、句长标准差、段长变异系数、词汇多样性、叙述连接词、技法多样性）做三区判定；只有缺失关键上下文时才回退旧 4 指标
+3. **可量化**：风格自然度优先基于 13 指标（黑名单命中率、句式重复率、句长标准差、段长变异系数、词汇多样性、叙述连接词、技法多样性、破折号计数、句式模式得分、比喻密度、对话区分度、省略号密度、感叹号密度）做三区判定；回退层级见 `style_naturalness` 评审口径
    - 若 prompt 中提供了黑名单精确统计 JSON（lint-blacklist），你必须使用其中的 `total_hits` / `hits_per_kchars` / `hits[]` 作为计数依据（忽略 whitelist/exemptions 的词条）
-   - 除 `blacklist_lint` 外，本 changeset 不依赖额外统计输入契约；`sentence_length_std_dev` / `paragraph_length_cv` / `vocabulary_richness_estimate` 由你基于正文估算，并在 `style_naturalness.reason` 中明确标注为“估计值”
+   - `sentence_length_std_dev` / `paragraph_length_cv` / `vocabulary_richness_estimate` / `simile_density` / `dialogue_distinguishability` / `ellipsis_density` / `exclamation_density` 由你基于正文估算，并在 `style_naturalness.reason` 中明确标注为”估计值”
 4. **综合分计算**：overall = 各维度 score × weight 的加权均值（权重优先来自 `manifest.inline.scoring_weights`；若缺失则使用 Track 2 默认表；`hook_strength` 若 weight=0.0 则不影响 overall）
 5. **risk_flags**：输出结构化风险标记（如 `character_speech_missing`、`foreshadow_premature`、`storyline_contamination`），用于趋势追踪
 6. **required_fixes**：当 recommendation 为 revise/review/rewrite 时，必须输出最小修订指令列表（target 段落 + 具体 instruction），供 ChapterWriter 定向修订
@@ -303,7 +317,7 @@ else:
     "violation_details": []
   },
   "anti_ai": {
-    "indicator_mode": "7-indicator | 4-indicator-compat",
+    "indicator_mode": "13-indicator | 7-indicator | 4-indicator-compat",
     "indicator_breakdown": {
       "blacklist_hit_rate": {"value": 2.4, "zone": "yellow", "note": "2.4 次/千字，仍有收缩空间"},
       "sentence_repetition_rate": {"value": "1/5", "zone": "green", "note": "相邻 5 句中只有 1 处重复句式"},
@@ -311,7 +325,13 @@ else:
       "paragraph_length_cv": {"value": 0.72, "zone": "green", "note": "段长起伏自然"},
       "vocabulary_diversity_score": {"value": "medium", "zone": "yellow", "note": "仍有少量高频表达回流"},
       "narration_connector_count": {"value": 1, "zone": "yellow", "note": "有 1 个孤立叙述连接词命中"},
-      "humanize_technique_variety": {"value": ["thought_interrupt", "mundane_detail"], "zone": "green", "note": "识别到 2 种自然技法，覆盖正常"}
+      "humanize_technique_variety": {"value": ["thought_interrupt", "mundane_detail"], "zone": "green", "note": "识别到 2 种自然技法，覆盖正常"},
+      "em_dash_count": {"value": 0, "zone": "green", "note": "无破折号"},
+      "sentence_pattern_score": {"value": "0 high, 1 medium", "zone": "green", "note": "仅 1 处 medium 命中，在阈值内"},
+      "simile_density": {"value": 0.6, "zone": "green", "note": "0.6 处/千字，像字比喻频率正常"},
+      "dialogue_distinguishability": {"value": "high", "zone": "green", "note": "去标签后角色语气差异明显"},
+      "ellipsis_density": {"value": 0.9, "zone": "green", "note": "省略号频率正常"},
+      "exclamation_density": {"value": 2.1, "zone": "green", "note": "感叹号频率正常"}
     },
     "blacklist_hits": {
       "total_hits": 12,
@@ -388,6 +408,7 @@ else:
 - **无故事线规范（M1 早期）**：M1 早期可能无 storyline-spec.json，跳过 LS 检查
 - **关键章双裁判模式**：卷首/卷尾/交汇事件章由入口 Skill 使用 Task(model=opus) 发起第二次调用并取较低分，QualityJudge 自身按正常流程执行即可
 - **lint-blacklist 缺失**：若未提供 lint 统计，你仍需给出黑名单命中率与例句，但需标注为估计值；若提供则以其为准
+- **13 指标上下文不足**：正文过短（<500 字）导致比喻/对话样本不足，或 `ai_sentence_patterns` 未提供时，回退 `indicator_mode: "7-indicator"`，仅输出前 7 项
 - **7 指标上下文不足**：若当前上下文拿不到可靠的句长 / 段长 / 词汇多样性 / 技法多样性判断，可回退 `indicator_mode: "4-indicator-compat"`，但必须在 `anti_ai` 中明确写出该模式
 - **黄金三章门控未注入**：当 `golden_chapter_gates` 与 `genre_golden_standards` 都缺失，或 `chapter > 3` 时，输出 `activated=false`；不要自行补造平台门控或题材门槛
 - **题材标准缺失/未命中**：当 `genre_golden_standards` 缺失，或 `brief.md` 题材无法命中配置时，跳过题材门槛，仅保留平台门控（如存在）

--- a/openspec/changes/m11-quality-judge-13-indicator-expansion/.openspec.yaml
+++ b/openspec/changes/m11-quality-judge-13-indicator-expansion/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-03-06
+depends_on:
+  - m10-anti-ai-sentence-pattern-hardening

--- a/openspec/changes/m11-quality-judge-13-indicator-expansion/design.md
+++ b/openspec/changes/m11-quality-judge-13-indicator-expansion/design.md
@@ -1,0 +1,88 @@
+## Context
+
+QualityJudge 当前 `anti_ai.indicator_breakdown` 输出 7 项指标，每项含 `value/zone/note`，用于 `style_naturalness` 维度的三区判定评分。m10 changeset 新增了句式模式检测（`sentence_pattern_violations[]`）和破折号零容忍（`punctuation_overuse.em_dash_zone`），但这些结果停留在独立输出对象中，未参与统一的三区判定体系。
+
+此外，style-guide 已定义但 QJ 未量化输出的维度包括：`像+具体意象` 比喻限频（§2.1）、对话区分度（§2.10 L4）、省略号/感叹号频率（§2.6）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 将 `indicator_breakdown` 从 7 项扩展到 13 项，所有维度统一 `value/zone/note` 三区输出
+- 定义 `indicator_mode: "13-indicator"` 为新默认，`"7-indicator"` 为中间回退
+- 保持 `punctuation_overuse` / `sentence_pattern_violations[]` 原有输出结构不变（向后兼容）
+- 更新 `style_naturalness` 评分映射：从 7 项三区 → 13 项三区
+
+**Non-Goals:**
+- 不改变 `sentence_pattern_violations[]` 的分项输出结构（仍保留 pattern_id/evidence/detail）
+- 不新增外部统计工具依赖（13 项均由 QJ 基于正文 LLM 估算或现有 lint 输入）
+- 不修改 ChapterWriter / StyleRefiner 的约束（它们已有对应规则，本次只补 QJ 的量化输出）
+- 不改变 `overall` 加权公式或门控阈值
+
+## Decisions
+
+### D1: 新增 6 项指标选择
+
+从已有规则/检测结果中提升 4 项，新建 2 项：
+
+| # | 指标 ID | 来源 | 理由 |
+|---|---------|------|------|
+| 8 | `em_dash_count` | `punctuation_overuse.em_dash_count` | 已有检测，零容忍是最硬约束，应在 indicator 层面直接可见 |
+| 9 | `sentence_pattern_score` | `sentence_pattern_violations[]` 聚合 | 已有分项数据，缺汇总 zone；聚合后可直接参与三区判定 |
+| 10 | `simile_density` | 正文扫描 `像+具体意象` | style-guide §2.1 有 ≤1/千字规则，但 QJ 无对应输出 |
+| 11 | `dialogue_distinguishability` | LLM 估算 | style-guide L4 有"去标签辨识度"自测要求，应量化 |
+| 12 | `ellipsis_density` | `punctuation_overuse.ellipsis_count` 换算 | §2.6 有 0-2/千字规则，应进入三区 |
+| 13 | `exclamation_density` | 正文扫描感叹号 | §2.6 有 0-3/千字规则，应进入三区 |
+
+**备选方案**：把 `idiom_density`（四字词组密度）也加入。**决定不加**——四字词组规则是结构规则（L3），更偏向 `structural_rule_violations[]` 的检查项而非统计指标，且"每 500 字 ≤3"的窗口检查不适合 per-kchars 的统一口径。
+
+### D2: 三区阈值定义
+
+| 指标 | green | yellow | red | 依据 |
+|------|-------|--------|-----|------|
+| `em_dash_count` | 0 | — | >0 | 零容忍，无 yellow 区间 |
+| `sentence_pattern_score` | 0 high + ≤2 medium | >2 medium + 0 high | ≥1 high | 与 style-guide L7 severity 对齐 |
+| `simile_density` | ≤1/千字 | 1-2/千字 | >2/千字 | style-guide §2.1 like_simile_rule |
+| `dialogue_distinguishability` | high | medium | low | 对应"去标签后可/勉强可/不可辨识" |
+| `ellipsis_density` | 0-2/千字 | 2-3/千字 | >3/千字 | style-guide §2.6 |
+| `exclamation_density` | 0-3/千字 | 3-5/千字 | >5/千字 | style-guide §2.6 |
+
+### D3: 回退层级（三档）
+
+```
+13-indicator（默认）
+  ↓ 当 simile_density / dialogue_distinguishability 无法可靠估算时
+7-indicator（中间回退）
+  ↓ 当 sentence_length_std_dev / paragraph_length_cv 等基础统计也无法获取时
+4-indicator-compat（legacy 回退）
+```
+
+回退触发条件：
+- 13 → 7：正文过短（<500 字）导致比喻/对话样本不足，或 `ai_sentence_patterns` 未提供
+- 7 → 4：正文破损或 style_profile 缺失（既有逻辑不变）
+
+### D4: 评分映射更新
+
+13 项三区判定 → `style_naturalness` 1-5 分映射：
+
+| 条件 | 分数 |
+|------|------|
+| 全 green | 5 |
+| 1-3 个 yellow，余下 green | 4 |
+| 4+ 个 yellow，或恰好 1 个 red | 3 |
+| 2-3 个 red | 2 |
+| 4+ 个 red | 1 |
+
+与现有 7 项映射规则一致（style-guide Layer 4），只是分母从 7 扩到 13。
+
+### D5: 向后兼容
+
+- `punctuation_overuse` 对象保留原有字段（`em_dash_count/em_dash_per_kchars/em_dash_zone/ellipsis_count/ellipsis_per_kchars`）
+- `sentence_pattern_violations[]` 保留分项输出
+- `statistical_profile` 保留 3 个 legacy 字段
+- 新增指标是纯增量，消费者若只读前 7 项仍可正常工作
+
+## Risks / Trade-offs
+
+- **[LLM 估算一致性]** `dialogue_distinguishability` 依赖 LLM 主观判断，不同模型/run 之间可能波动 → 通过明确评估口径（"去掉对话标签后，仅凭语气/用词/句式能否分辨说话人"）和三档枚举（high/medium/low）降低波动
+- **[指标膨胀]** 13 项可能让单个 red 的影响被稀释 → 保留 `em_dash_count` 的"无 yellow 直接 red"设计，且 sentence_pattern_score 的 high 命中仍独立触发至少降 1 分的叠加扣分
+- **[回退复杂度]** 三档回退增加判断分支 → 触发条件明确且单向递降，实际只多一个 if 分支

--- a/openspec/changes/m11-quality-judge-13-indicator-expansion/proposal.md
+++ b/openspec/changes/m11-quality-judge-13-indicator-expansion/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+QualityJudge 的 `indicator_breakdown` 当前仅输出 7 项指标的三区判定（green/yellow/red），但实际评审过程中已经在检测更多维度（破折号合规、句式模式命中、省略号/感叹号频率），这些结果散落在 `punctuation_overuse`、`sentence_pattern_violations[]` 等独立对象中，无法统一进入三区判定体系。此外，比喻密度（`像+具体意象`）和对话区分度两个维度有明确的规则定义（style-guide §2.1 / §2.10 L4）却完全没有量化输出。这导致：
+
+1. **评分盲区**：6 个已有规则/检测结果未参与 `style_naturalness` 的三区综合判定
+2. **审计断裂**：消费者需要从 3 个不同对象拼凑完整画面，无法用统一接口回溯
+3. **回退粒度粗**：当前只有 `7-indicator` 和 `4-indicator-compat` 两档，缺少中间层
+
+## What Changes
+
+- `indicator_breakdown` 从 7 项扩展到 13 项，新增 6 个指标并定义各自的 green/yellow/red 三区阈值
+- `indicator_mode` 新增 `"13-indicator"` 作为默认模式；`"7-indicator"` 降级为中间回退；`"4-indicator-compat"` 保留
+- `style_naturalness` 评分映射规则更新：13 项三区判定 → 1-5 分
+- `punctuation_overuse` 和 `sentence_pattern_violations[]` 保留原有输出结构（向后兼容），同时将汇总值提升到 `indicator_breakdown`
+- style-guide Layer 4 三区判定表从 7 行扩展到 13 行
+- quality-rubric `style_naturalness` 维度补充新指标参考
+
+## Capabilities
+
+### New Capabilities
+- `13-indicator-expansion`: QualityJudge indicator_breakdown 从 7 项扩展到 13 项，含三区阈值定义、评分映射、回退层级
+
+### Modified Capabilities
+
+（无既有 spec 需修改）
+
+## Impact
+
+- `agents/quality-judge.md` — indicator_breakdown 输出结构、indicator_mode 枚举、style_naturalness 评审口径、Format JSON 示例
+- `skills/novel-writing/references/style-guide.md` — Layer 4 三区判定表扩展
+- `skills/novel-writing/references/quality-rubric.md` — style_naturalness 维度说明
+- 向后兼容：`punctuation_overuse` / `sentence_pattern_violations[]` / `statistical_profile` 保留不动，新增指标为纯增量

--- a/openspec/changes/m11-quality-judge-13-indicator-expansion/specs/13-indicator-expansion/spec.md
+++ b/openspec/changes/m11-quality-judge-13-indicator-expansion/specs/13-indicator-expansion/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: 13-indicator indicator_breakdown
+
+QualityJudge 的 `anti_ai.indicator_breakdown` SHALL 输出 13 项指标，每项包含 `value`、`zone`（green | yellow | red）、`note`。前 7 项保持现有定义不变，新增以下 6 项：
+
+| # | 指标 ID | value 类型 | green | yellow | red |
+|---|---------|-----------|-------|--------|-----|
+| 8 | `em_dash_count` | number | 0 | （无 yellow） | >0 |
+| 9 | `sentence_pattern_score` | string 摘要 | 0 high + ≤2 medium | >2 medium + 0 high | ≥1 high |
+| 10 | `simile_density` | number（/千字） | ≤1 | >1 且 ≤2 | >2 |
+| 11 | `dialogue_distinguishability` | enum: high/medium/low | high | medium | low |
+| 12 | `ellipsis_density` | number（/千字） | ≤2 | >2 且 ≤3 | >3 |
+| 13 | `exclamation_density` | number（/千字） | ≤3 | >3 且 ≤5 | >5 |
+
+#### Scenario: 全部 13 项正常输出
+
+- **WHEN** QualityJudge 以 `indicator_mode: "13-indicator"` 评审一个标准章节（≥500 字，`ai_sentence_patterns` 存在）
+- **THEN** `indicator_breakdown` MUST 包含 13 个 key，每个 key 含 `value`/`zone`/`note`
+
+#### Scenario: em_dash_count 零容忍
+
+- **WHEN** 章节正文包含 1 个或以上破折号（——）
+- **THEN** `indicator_breakdown.em_dash_count.zone` MUST 为 `"red"`，且 `value` 为实际计数
+
+#### Scenario: em_dash_count 无 yellow 区间
+
+- **WHEN** 章节正文包含 0 个破折号
+- **THEN** `indicator_breakdown.em_dash_count.zone` MUST 为 `"green"`（不存在 yellow 判定）
+
+#### Scenario: sentence_pattern_score 聚合
+
+- **WHEN** `sentence_pattern_violations[]` 包含 1 处 severity=high 命中
+- **THEN** `indicator_breakdown.sentence_pattern_score.zone` MUST 为 `"red"`
+
+#### Scenario: simile_density 计算
+
+- **WHEN** 3000 字章节中出现 4 处 `像+具体意象` 比喻（排除非比喻义 `好像`/`像是`）
+- **THEN** `indicator_breakdown.simile_density.value` ≈ 1.33，`zone` 为 `"yellow"`
+
+#### Scenario: dialogue_distinguishability 评估
+
+- **WHEN** 章节含多角色对话，去掉对话标签后读者仅能勉强分辨说话人
+- **THEN** `indicator_breakdown.dialogue_distinguishability.value` 为 `"medium"`，`zone` 为 `"yellow"`
+
+#### Scenario: ellipsis_density 与 exclamation_density
+
+- **WHEN** 3000 字章节包含 10 个省略号和 18 个感叹号
+- **THEN** `ellipsis_density.value` ≈ 3.33，`zone` 为 `"red"`；`exclamation_density.value` = 6.0，`zone` 为 `"red"`
+
+### Requirement: indicator_mode 三档回退
+
+`anti_ai.indicator_mode` SHALL 支持三档：`"13-indicator"`（默认）、`"7-indicator"`（中间回退）、`"4-indicator-compat"`（legacy）。
+
+#### Scenario: 默认 13-indicator 模式
+
+- **WHEN** 正文 ≥500 字、`ai_sentence_patterns` 存在、对话内容足以评估区分度
+- **THEN** `indicator_mode` MUST 为 `"13-indicator"`
+
+#### Scenario: 回退到 7-indicator
+
+- **WHEN** 正文过短（<500 字）导致比喻/对话样本不足，或 `ai_sentence_patterns` 未提供
+- **THEN** `indicator_mode` MUST 为 `"7-indicator"`，`indicator_breakdown` 仅包含前 7 项
+
+#### Scenario: 回退到 4-indicator-compat
+
+- **WHEN** 正文破损或 style_profile 缺失导致基础统计无法估算
+- **THEN** `indicator_mode` MUST 为 `"4-indicator-compat"`（既有行为不变）
+
+### Requirement: style_naturalness 评分映射更新
+
+`style_naturalness` 维度在 `indicator_mode: "13-indicator"` 时 SHALL 按 13 项三区判定进行 1-5 分映射。
+
+#### Scenario: 全 green → 5 分
+
+- **WHEN** 13 项指标全部为 green
+- **THEN** `style_naturalness` 基础分为 5（句式模式叠加扣分另计）
+
+#### Scenario: 1-3 yellow → 4 分
+
+- **WHEN** 13 项中 1-3 个 yellow，余下 green，无 red
+- **THEN** `style_naturalness` 基础分为 4
+
+#### Scenario: 4+ yellow 或 1 red → 3 分
+
+- **WHEN** 13 项中 ≥4 个 yellow 或恰好 1 个 red
+- **THEN** `style_naturalness` 基础分为 3
+
+#### Scenario: 2-3 red → 2 分
+
+- **WHEN** 13 项中 2-3 个 red
+- **THEN** `style_naturalness` 基础分为 2
+
+#### Scenario: 4+ red → 1 分
+
+- **WHEN** 13 项中 ≥4 个 red
+- **THEN** `style_naturalness` 基础分为 1
+
+### Requirement: 向后兼容
+
+新增指标 SHALL 为纯增量，不修改或删除 `punctuation_overuse`、`sentence_pattern_violations[]`、`statistical_profile` 的既有字段。
+
+#### Scenario: punctuation_overuse 保留
+
+- **WHEN** 消费者读取 `anti_ai.punctuation_overuse`
+- **THEN** 所有既有字段（`em_dash_count/em_dash_per_kchars/em_dash_zone/ellipsis_count/ellipsis_per_kchars`）MUST 仍然存在且语义不变
+
+#### Scenario: sentence_pattern_violations 保留
+
+- **WHEN** 消费者读取 `anti_ai.sentence_pattern_violations[]`
+- **THEN** 分项输出（`pattern_id/pattern_name/severity/count/evidence/detail`）MUST 仍然存在
+
+### Requirement: style-guide Layer 4 三区判定表扩展
+
+style-guide Layer 4 的三区判定表 SHALL 从 7 行扩展到 13 行，覆盖全部新增指标的 green/yellow/red 阈值定义和升级提示。
+
+#### Scenario: 文档一致性
+
+- **WHEN** 开发者查阅 style-guide Layer 4
+- **THEN** 表中 MUST 包含 13 项指标的完整三区定义，与 QJ agent prompt 中的阈值一致
+
+### Requirement: quality-rubric 参考更新
+
+quality-rubric 的 `style_naturalness` 维度 SHALL 注明 13 项指标参考和回退说明。
+
+#### Scenario: rubric 文档更新
+
+- **WHEN** 开发者查阅 quality-rubric `style_naturalness` 维度
+- **THEN** MUST 能看到 13 项指标的简要列表和"13 → 7 → 4 回退"的说明

--- a/openspec/changes/m11-quality-judge-13-indicator-expansion/tasks.md
+++ b/openspec/changes/m11-quality-judge-13-indicator-expansion/tasks.md
@@ -1,0 +1,30 @@
+## 1. style-guide Layer 4 三区判定表扩展
+
+- [x] 1.1 扩展 `style-guide.md` Layer 4 三区判定表从 7 行到 13 行，新增 6 项指标的 green/yellow/red 阈值
+- [x] 1.2 更新评分映射建议（全 green → 5 分等）的分母说明从 7 项到 13 项
+- [x] 1.3 更新升级提示，说明 13 → 7 → 4 三档回退机制
+
+## 2. quality-rubric 更新
+
+- [x] 2.1 更新 `quality-rubric.md` style_naturalness 维度，列出 13 项指标并注明回退说明
+
+## 3. QualityJudge agent prompt 更新
+
+- [x] 3.1 更新 `indicator_mode` 枚举：新增 `"13-indicator"` 为默认，`"7-indicator"` 为中间回退
+- [x] 3.2 在 `style_naturalness` 评审口径中列出全部 13 项指标
+- [x] 3.3 新增 6 项指标的评估规则（em_dash_count / sentence_pattern_score / simile_density / dialogue_distinguishability / ellipsis_density / exclamation_density）
+- [x] 3.4 更新 `indicator_breakdown` Format JSON 示例，展示 13 项完整输出
+- [x] 3.5 更新回退条件：13 → 7 的触发规则
+- [x] 3.6 更新 Constraint 3 的描述，从"7 指标"改为"13 指标"
+- [x] 3.7 更新 Edge Cases 中的回退说明
+
+## 4. OpenSpec 元数据
+
+- [x] 4.1 更新 `.openspec.yaml` 添加 `depends_on: [m10-anti-ai-sentence-pattern-hardening]`
+
+## 5. 验证
+
+- [x] 5.1 `grep -c "13-indicator" agents/quality-judge.md` → 3 处确认
+- [x] 5.2 style-guide Layer 4 表格包含 13 项指标（含表头 14 行）
+- [x] 5.3 QJ Format JSON 示例中 indicator_breakdown 有 13 个 `"zone":` 匹配
+- [x] 5.4 punctuation_overuse（2 处） / sentence_pattern_violations（4 处）原有字段保留

--- a/skills/novel-writing/references/quality-rubric.md
+++ b/skills/novel-writing/references/quality-rubric.md
@@ -66,7 +66,9 @@
 
 ## 6. 风格自然度（style_naturalness）— 权重 0.15
 
-评估去 AI 化效果，基于可量化指标。
+评估去 AI 化效果，基于可量化指标。默认使用 13 项三区判定（`indicator_mode: "13-indicator"`）；正文过短或 `ai_sentence_patterns` 缺失时回退到 7 项；正文破损或 style_profile 缺失时回退到 4 项 legacy 模式。
+
+13 项指标：`blacklist_hit_rate` / `sentence_repetition_rate` / `sentence_length_std_dev` / `paragraph_length_cv` / `vocabulary_diversity_score` / `narration_connector_count` / `humanize_technique_variety` / `em_dash_count` / `sentence_pattern_score` / `simile_density` / `dialogue_distinguishability` / `ellipsis_density` / `exclamation_density`。详见 style-guide Layer 4 三区判定表。
 
 | 分数 | AI 黑名单命中率 | 句式重复率（相邻 5 句） | style-profile 匹配度 | 句式模式命中 |
 |------|----------------|----------------------|---------------------|-------------|

--- a/skills/novel-writing/references/style-guide.md
+++ b/skills/novel-writing/references/style-guide.md
@@ -400,26 +400,36 @@ StyleRefiner 默认按 §2.12 的四步流程执行，并额外遵守：
 
 ## Layer 4: 检测度量（QualityJudge）
 
-### 风格自然度三区判定（7 指标）
+### 风格自然度三区判定（13 指标）
 
-| 指标 | green（人类范围） | yellow（边界） | red（AI 特征） |
-|------|------------------|----------------|----------------|
-| `blacklist_hit_rate` | 0-1 次/千字 | 1-3 次/千字 | >3 次/千字 |
-| `sentence_repetition_rate` | 相邻 5 句中 0-1 个重复句式 | 相邻 5 句中 2 个重复句式 | 相邻 5 句中 ≥3 个重复句式 |
-| `sentence_length_std_dev` | 8-18，或落在 style-profile 目标附近 | 6-8 或 18-24 | <6（过匀） |
-| `paragraph_length_cv` | 0.4-1.2，或落在 style-profile 目标附近 | 0.3-0.4 或 1.2-1.5 | <0.3（过匀） |
-| `vocabulary_diversity_score` | 当前仅有枚举时 `vocabulary_richness=high`；若未来提供数值字段，则 ≥0.45 | 当前仅有枚举时 `medium`；若未来提供数值字段，则 0.35-0.45 | 当前仅有枚举时 `low`；若未来提供数值字段，则 <0.35 |
-| `narration_connector_count` | 0 | 1 个孤立命中（仍应改写） | ≥2 个，或连续多段靠连接词推进 |
-| `humanize_technique_variety` | 单章自然出现 ≥1 种不同技法，且无刷项感 | 0，且其余指标未出现 red（不阻断，但提示检查是否过匀） | 0，且同时伴随至少 1 项句式/连接词等其它 red |
+| # | 指标 | green（人类范围） | yellow（边界） | red（AI 特征） |
+|---|------|------------------|----------------|----------------|
+| 1 | `blacklist_hit_rate` | 0-1 次/千字 | 1-3 次/千字 | >3 次/千字 |
+| 2 | `sentence_repetition_rate` | 相邻 5 句中 0-1 个重复句式 | 相邻 5 句中 2 个重复句式 | 相邻 5 句中 ≥3 个重复句式 |
+| 3 | `sentence_length_std_dev` | 8-18，或落在 style-profile 目标附近 | 6-8 或 18-24 | <6（过匀） |
+| 4 | `paragraph_length_cv` | 0.4-1.2，或落在 style-profile 目标附近 | 0.3-0.4 或 1.2-1.5 | <0.3（过匀） |
+| 5 | `vocabulary_diversity_score` | 当前仅有枚举时 `vocabulary_richness=high`；若未来提供数值字段，则 ≥0.45 | 当前仅有枚举时 `medium`；若未来提供数值字段，则 0.35-0.45 | 当前仅有枚举时 `low`；若未来提供数值字段，则 <0.35 |
+| 6 | `narration_connector_count` | 0 | 1 个孤立命中（仍应改写） | ≥2 个，或连续多段靠连接词推进 |
+| 7 | `humanize_technique_variety` | 单章自然出现 ≥1 种不同技法，且无刷项感 | 0，且其余指标未出现 red（不阻断，但提示检查是否过匀） | 0，且同时伴随至少 1 项句式/连接词等其它 red |
+| 8 | `em_dash_count` | 0 | （无 yellow） | >0（零容忍） |
+| 9 | `sentence_pattern_score` | 0 处 high + ≤2 处 medium | >2 处 medium + 0 处 high | ≥1 处 high 命中 |
+| 10 | `simile_density` | ≤1 处/千字 | >1 且 ≤2 处/千字 | >2 处/千字 |
+| 11 | `dialogue_distinguishability` | high（去标签后可辨识） | medium（勉强可辨识） | low（无法辨识） |
+| 12 | `ellipsis_density` | 0-2 处/千字 | >2 且 ≤3 处/千字 | >3 处/千字 |
+| 13 | `exclamation_density` | 0-3 处/千字 | >3 且 ≤5 处/千字 | >5 处/千字 |
 
 > `vocabulary_diversity` 是方法名，`vocabulary_richness` 是现行 style-profile 字段，`vocabulary_diversity_score` 是 Layer 4 观测指标名；三者指向同一维度的不同层名。
 > `humanize_technique_variety` 是复合条件指标，也是事后观察指标，不是生成配额；不要为了把分数刷到 green，机械往章节里塞技法。
-> green 表示“仍在人类可接受范围”，不等于旧 5 分制的满分；若沿用 Legacy Fallback 或旧 `quality-rubric` 打满分，`blacklist_hit_rate` 仍建议压到 0 次/千字。
+> `em_dash_count` 无 yellow 区间：破折号是最明显的 AI 写作标志，只要出现即为 red。
+> `sentence_pattern_score` 聚合自 `sentence_pattern_violations[]`；分项证据仍保留在独立数组中。
+> `simile_density` 仅计 `像+具体意象`（如”像一把刀”），排除非比喻义（”好像有人来了””像是累了”）。
+> `dialogue_distinguishability` 由 LLM 基于”去掉对话标签后，仅凭语气/用词/句式能否分辨说话人”进行估算。
+> green 表示”仍在人类可接受范围”，不等于旧 5 分制的满分；若沿用 Legacy Fallback 或旧 `quality-rubric` 打满分，`blacklist_hit_rate` 仍建议压到 0 次/千字。
 
 建议映射：
 - 全 green → 5 分
-- 1-2 个 yellow，余下为 green → 4 分
-- 3 个及以上 yellow，或恰好 1 个 red → 3 分
+- 1-3 个 yellow，余下为 green → 4 分
+- 4 个及以上 yellow，或恰好 1 个 red → 3 分
 - 2-3 个 red → 2 分
 - 4 个及以上 red → 1 分
 
@@ -437,9 +447,9 @@ StyleRefiner 默认按 §2.12 的四步流程执行，并额外遵守：
 
 ### 升级提示
 
-- 旧项目若还没有新的统计字段，可先继续使用 `vocabulary_richness` 等枚举代理，并在无法取得 7 指标时回退到 Legacy Fallback
+- 旧项目若还没有新的统计字段，可先继续使用 `vocabulary_richness` 等枚举代理，并在无法取得 13 指标时回退到 7 指标或 Legacy Fallback
+- 回退层级：`13-indicator`（默认）→ `7-indicator`（正文过短或 `ai_sentence_patterns` 缺失时）→ `4-indicator-compat`（正文破损或 style_profile 缺失时）
 - 现有章节不需要立刻整库重评；从下次重跑 StyleAnalyzer、StyleRefiner、QualityJudge 时逐步补齐即可
-- 本次变更只更新方法论基线；`agents/style-refiner.md`、`agents/quality-judge.md` 等消费方定义仍按后续 CS-A3 / CS-A4 changeset 跟进
 
 ### 黑名单维护机制
 


### PR DESCRIPTION
## Summary
- `indicator_breakdown` 从 7 项扩展到 13 项，新增 `em_dash_count` / `sentence_pattern_score` / `simile_density` / `dialogue_distinguishability` / `ellipsis_density` / `exclamation_density`
- 三档回退：`13-indicator`（默认）→ `7-indicator` → `4-indicator-compat`
- 同步更新 style-guide Layer 4 三区表和 quality-rubric

## Changed Files
- `agents/quality-judge.md` — 13 项指标定义 + 评估规则 + Format 示例
- `skills/novel-writing/references/style-guide.md` — Layer 4 表 7→13 行
- `skills/novel-writing/references/quality-rubric.md` — style_naturalness 说明
- `openspec/changes/m11-*/` — changeset 文档

## Test plan
- [x] grep 确认 `13-indicator` 出现在 QJ agent prompt
- [x] 确认 indicator_breakdown JSON 示例有 13 个 key
- [x] 确认 punctuation_overuse / sentence_pattern_violations 向后兼容保留
- [x] 确认 style-guide 表格 13 行 + 阈值与 QJ 一致
- [x] 4 agent 交叉审核全部 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)